### PR TITLE
AI001: Thêm entity Schools, Classes và API lấy danh sách trường học

### DIFF
--- a/src/main/java/com/bkap/aispark/api/SchoolApi.java
+++ b/src/main/java/com/bkap/aispark/api/SchoolApi.java
@@ -1,0 +1,27 @@
+package com.bkap.aispark.api;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bkap.aispark.entity.Schools;
+import com.bkap.aispark.repository.SchoolsRepository;
+
+@RestController
+@RequestMapping("/schools")
+public class SchoolApi {
+
+    private final SchoolsRepository schoolRepository;
+
+    public SchoolApi(SchoolsRepository schoolRepository) {
+        this.schoolRepository = schoolRepository;
+    }
+
+    @GetMapping
+    public List<Schools> getAllSchools() {
+        return schoolRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/bkap/aispark/entity/Classes.java
+++ b/src/main/java/com/bkap/aispark/entity/Classes.java
@@ -1,0 +1,56 @@
+package com.bkap.aispark.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "classes")
+public class Classes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    // Liên kết nhiều lớp thuộc về 1 trường (ManyToOne)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    @JsonIgnore
+    private Schools school;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Schools getSchool() {
+        return school;
+    }
+
+    public void setSchool(Schools school) {
+        this.school = school;
+    }
+
+}

--- a/src/main/java/com/bkap/aispark/entity/Schools.java
+++ b/src/main/java/com/bkap/aispark/entity/Schools.java
@@ -1,0 +1,63 @@
+package com.bkap.aispark.entity;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "schools")
+public class Schools {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String address;
+
+    @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    private List<Classes> classes;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public List<Classes> getClasses() {
+        return classes;
+    }
+
+    public void setClasses(List<Classes> classes) {
+        this.classes = classes;
+    }
+
+    // getter, setter
+}

--- a/src/main/java/com/bkap/aispark/repository/SchoolsRepository.java
+++ b/src/main/java/com/bkap/aispark/repository/SchoolsRepository.java
@@ -1,0 +1,8 @@
+package com.bkap.aispark.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bkap.aispark.entity.Schools;
+
+public interface SchoolsRepository extends JpaRepository<Schools, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,11 @@ spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 spring.thymeleaf.cache=false
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/AI_BKAP
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/AI_Bkap
 spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.password=123456
+
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Mục tiêu
- Xây dựng mô hình dữ liệu Schools và Classes.
- Tạo API để lấy danh sách trường học từ DB.
Thay đổi chính
- Entity
   + Schools:
      * Thuộc tính: id, name, address.
      * Quan hệ: OneToMany với Classes.
   + Classes:
      * Thuộc tính: id, name.
      * Quan hệ: ManyToOne với Schools.
- Repository
    + SchoolsRepository extends JpaRepository<Schools, Long>.
- API
    + SchoolApi: 
       * Endpoint GET /schools → trả về danh sách tất cả trường.
 
 ẢNH MÔ TẢ 
 
<img width="560" height="681" alt="image" src="https://github.com/user-attachments/assets/65dfbbe9-163d-435f-9728-ac04cb62dffc" />
